### PR TITLE
Tag 1 is no longer restricted to the Mixcloud default options

### DIFF
--- a/classes/Recording.php
+++ b/classes/Recording.php
@@ -126,12 +126,7 @@ class Recording {
 
         if (!empty($tag)) {
             if (strlen($tag) > 20) throw new Exception("Tag was too long.");
-
-            // If this is the first tag being added and it's not a default tag, throw exception
-            if (sizeof($this->tags) == 0 && !in_array($tag, Recording::$PRIMARY_TAG_OPTIONS)) {
-                throw new Exception("First tag isn't a default tag, but it should be.");
-            }
-
+            
             $this->tags[] = $tag;
         }
     }

--- a/scripts/formHandler.php
+++ b/scripts/formHandler.php
@@ -66,8 +66,7 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
         }
 
         $recording->setDescription($_POST["description"]);
-        if (isset($_POST["tag1"])) // suppress warning since this isn't sent at all if no tag selected
-            $recording->addTag($_POST["tag1"]);
+        $recording->addTag($_POST["tag1"]);
         $recording->addTag($_POST["tag2"]);
         $recording->addTag($_POST["tag3"]);
         $recording->addTag($_POST["tag4"]);

--- a/www/metadata.php
+++ b/www/metadata.php
@@ -89,31 +89,30 @@ if (isset($_POST["id"]) && is_numeric($_POST["id"])) {
         </div>
         
         <div class="form-group">
-            <label class="mb-2">Tags</label>
-            <select class="form-select joint-input-top" id="tag1" aria-label="Tag" aria-describedby="tagsHelp" name="tag1">
-                <option value="" disabled selected>Choose primary tag...</option>
-                <?php
-                    foreach (Recording::$PRIMARY_TAG_OPTIONS as $tag) {
-                        $selected = "";
-                        if (isset($defaultData["tags"][0]) && $tag == $defaultData["tags"][0]) {
-                            $selected = "selected";
+            <fieldset>
+                <legend class="fs-6 mb-2">Tags</legend>
+                <input type="text" class="form-control joint-input-top" aria-label="Tag" aria-describedby="tagsHelp"
+                    id="tag1" name="tag1" maxlength="20" list="tagSuggestions" value="<?php echo $defaultData["tags"][0] ?? ""; ?>">
+                <input type="text" class="form-control joint-input-middle" aria-label="Tag" aria-describedby="tagsHelp"
+                    id="tag2" name="tag2" maxlength="20" list="tagSuggestions" value="<?php echo $defaultData["tags"][1] ?? ""; ?>">
+                <input type="text" class="form-control joint-input-middle" aria-label="Tag" aria-describedby="tagsHelp"
+                    id="tag3" name="tag3" maxlength="20" list="tagSuggestions" value="<?php echo $defaultData["tags"][2] ?? ""; ?>">
+                <input type="text" class="form-control joint-input-middle" aria-label="Tag" aria-describedby="tagsHelp"
+                    id="tag4" name="tag4" maxlength="20" list="tagSuggestions" value="<?php echo $defaultData["tags"][3] ?? ""; ?>">
+                <input type="text" class="form-control joint-input-bottom" aria-label="Tag" aria-describedby="tagsHelp"
+                    id="tag5" name="tag5" maxlength="20" list="tagSuggestions" value="<?php echo $defaultData["tags"][4] ?? ""; ?>">
+                <small id="tagsHelp" class="form-text text-muted">
+                    Good tags are things like the genres of music in the show. Click into the box to see popular tags, or type your 
+                    own. More popular tags will suggest your show to more people.
+                </small>
+                <datalist id="tagSuggestions">
+                    <?php
+                        foreach (Recording::$PRIMARY_TAG_OPTIONS as $tag) {
+                            echo '<option value="' . $tag . '"></option>';
                         }
-                        echo '<option value="' . $tag . '" ' . $selected . '>' . $tag. '</option>';
-                    }
-                ?>
-            </select>
-            <input type="text" class="form-control joint-input-middle" aria-label="Tag" aria-describedby="tagsHelp"
-                   id="tag2" name="tag2" maxlength="20" value="<?php echo $defaultData["tags"][1] ?? ""; ?>">
-            <input type="text" class="form-control joint-input-middle" aria-label="Tag" aria-describedby="tagsHelp"
-                   id="tag3" name="tag3" maxlength="20" value="<?php echo $defaultData["tags"][2] ?? ""; ?>">
-            <input type="text" class="form-control joint-input-middle" aria-label="Tag" aria-describedby="tagsHelp"
-                   id="tag4" name="tag4" maxlength="20" value="<?php echo $defaultData["tags"][3] ?? ""; ?>">
-            <input type="text" class="form-control joint-input-bottom" aria-label="Tag" aria-describedby="tagsHelp"
-                   id="tag5" name="tag5" maxlength="20" value="<?php echo $defaultData["tags"][4] ?? ""; ?>">
-            <small id="tagsHelp" class="form-text text-muted">
-                Good tags are things like the genres of music in the show. Pick the first from the dropdown, and
-                type up to four more into the boxes.
-            </small>
+                    ?>
+                </datalist>
+            </fieldset>
         </div>
 
         <?php


### PR DESCRIPTION
There was a bug where leaving the first tag blank (i.e. not picking one from the dropdown) but then typing one into a box would make the upload fail.

It turns out that Mixcloud does not require the use of one of their default tags, so this PR:
* Removes the requirement for a tag to be selected from the default list.
* Replaces the `select` dropdown with a `datalist` applied to all tag entry fields.

This means users can enter arbitrary tags or select from a list for all five tags, rather than selecting from a list for the first and making up the other four without help.